### PR TITLE
Memcached::get() expects parameter 2 to be a valid callback

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -297,25 +297,19 @@ function wp_cache_flush( $delay = 0 ) {
  *
  * @param string        $key        The key under which to store the value.
  * @param string        $group      The group value appended to the $key.
+ * @param bool          $force      Whether or not to force a cache invalidation.
+ * @param null|bool     $found      Variable passed by reference to determine if the value was found or not.
  * @param null|string   $cache_cb   Read-through caching callback.
  * @param null|float    $cas_token  The variable to store the CAS token in.
  * @return bool|mixed               Cached object value.
  */
-function wp_cache_get( $key, $group = '', $cache_cb = null, &$cas_token = null ) {
+function wp_cache_get( $key, $group = '', $force = false, &$found = null, $cache_cb = null, &$cas_token = null ) {
 	global $wp_object_cache;
 
-	/**
-	 * Handles situations where the $force argument for the wp_cache_get function in core may be used. It is only
-	 * used once in all of WP Core and since the function does not do anything with it, it is pointless to support.
-	 * I'm catching the issue here to avoid conflicts.
-	 */
-	if ( true === $cache_cb )
-		$cache_cb = null;
-
-	if ( func_num_args() > 2 )
-		return $wp_object_cache->get( $key, $group, '', false, $cache_cb, $cas_token );
+	if ( func_num_args() > 4 )
+		return $wp_object_cache->get( $key, $group, $force, $found, '', false, $cache_cb, $cas_token );
 	else
-		return $wp_object_cache->get( $key, $group );
+		return $wp_object_cache->get( $key, $group, $force, $found );
 }
 
 /**
@@ -1245,17 +1239,19 @@ class WP_Object_Cache {
 	 *
 	 * @param   string          $key        The key under which to store the value.
 	 * @param   string          $group      The group value appended to the $key.
+	 * @param   bool            $force      Whether or not to force a cache invalidation.
+	 * @param   null|bool       $found      Variable passed by reference to determine if the value was found or not.
 	 * @param   string          $server_key The key identifying the server to store the value on.
 	 * @param   bool            $byKey      True to store in internal cache by key; false to not store by key
 	 * @param   null|callable   $cache_cb   Read-through caching callback.
 	 * @param   null|float      $cas_token  The variable to store the CAS token in.
 	 * @return  bool|mixed                  Cached object value.
 	 */
-	public function get( $key, $group = 'default', $server_key = '', $byKey = false, $cache_cb = NULL, &$cas_token = NULL ) {
+	public function get( $key, $group = 'default', $force = false, &$found = null, $server_key = '', $byKey = false, $cache_cb = NULL, &$cas_token = NULL ) {
 		$derived_key = $this->buildKey( $key, $group );
 
 		// If either $cache_db, or $cas_token is set, must hit Memcached and bypass runtime cache
-		if ( func_num_args() > 4 && ! in_array( $group, $this->no_mc_groups ) ) {
+		if ( func_num_args() > 6 && ! in_array( $group, $this->no_mc_groups ) ) {
 			if ( $byKey )
 				$value = $this->m->getByKey( $server_key, $derived_key, $cache_cb, $cas_token );
 			else

--- a/object-cache.php
+++ b/object-cache.php
@@ -325,17 +325,19 @@ function wp_cache_get( $key, $group = '', $force = false, &$found = null, $cache
  * @param string        $server_key The key identifying the server to store the value on.
  * @param string        $key        The key under which to store the value.
  * @param string        $group      The group value appended to the $key.
+ * @param bool          $force      Whether or not to force a cache invalidation.
+ * @param null|bool     $found      Variable passed by reference to determine if the value was found or not.
  * @param null|string   $cache_cb   Read-through caching callback.
  * @param null|float    $cas_token  The variable to store the CAS token in.
  * @return bool|mixed               Cached object value.
  */
-function wp_cache_get_by_key( $server_key, $key, $group = '', $cache_cb = NULL, &$cas_token = NULL ) {
+function wp_cache_get_by_key( $server_key, $key, $group = '', $force = false, &$found = null, $cache_cb = NULL, &$cas_token = NULL ) {
 	global $wp_object_cache;
 
-	if ( func_num_args() > 3 )
-		return $wp_object_cache->getByKey( $server_key, $key, $group, $cache_cb, $cas_token );
+	if ( func_num_args() > 5 )
+		return $wp_object_cache->getByKey( $server_key, $key, $group, $force, $found, $cache_cb, $cas_token );
 	else
-		return $wp_object_cache->getByKey( $server_key, $key, $group );
+		return $wp_object_cache->getByKey( $server_key, $key, $group, $force, $found );
 }
 
 /**
@@ -1298,19 +1300,21 @@ class WP_Object_Cache {
 	 * @param   string          $server_key The key identifying the server to store the value on.
 	 * @param   string          $key        The key under which to store the value.
 	 * @param   string          $group      The group value appended to the $key.
+	 * @param   bool            $force      Whether or not to force a cache invalidation.
+	 * @param   null|bool       $found      Variable passed by reference to determine if the value was found or not.
 	 * @param   null|string     $cache_cb   Read-through caching callback.
 	 * @param   null|float      $cas_token  The variable to store the CAS token in.
 	 * @return  bool|mixed                  Cached object value.
 	 */
-	public function getByKey( $server_key, $key, $group = 'default', $cache_cb = NULL, &$cas_token = NULL ) {
+	public function getByKey( $server_key, $key, $group = 'default', $force = false, &$found = null, $cache_cb = NULL, &$cas_token = NULL ) {
 		/**
 		 * Need to be careful how "get" is called. If you send $cache_cb, and $cas_token, it will hit memcached.
 		 * Only send those args if they were sent to this function.
 		 */
-		if ( func_num_args() > 3 )
-			return $this->get( $key, $group, $server_key, true, $cache_cb, $cas_token );
+		if ( func_num_args() > 5 )
+			return $this->get( $key, $group, $force, $found, $server_key, true, $cache_cb, $cas_token );
 		else
-			return $this->get( $key, $group, $server_key, true );
+			return $this->get( $key, $group, $force, $found, $server_key, true );
 	}
 
 	/**

--- a/object-cache.php
+++ b/object-cache.php
@@ -1250,6 +1250,9 @@ class WP_Object_Cache {
 	public function get( $key, $group = 'default', $force = false, &$found = null, $server_key = '', $byKey = false, $cache_cb = NULL, &$cas_token = NULL ) {
 		$derived_key = $this->buildKey( $key, $group );
 
+		// Assume object is not found
+		$found = false;
+
 		// If either $cache_db, or $cas_token is set, must hit Memcached and bypass runtime cache
 		if ( func_num_args() > 6 && ! in_array( $group, $this->no_mc_groups ) ) {
 			if ( $byKey )
@@ -1258,6 +1261,7 @@ class WP_Object_Cache {
 				$value = $this->m->get( $derived_key, $cache_cb, $cas_token );
 		} else {
 			if ( isset( $this->cache[$derived_key] ) ) {
+				$found = true;
 				return is_object( $this->cache[$derived_key] ) ? clone $this->cache[$derived_key] : $this->cache[$derived_key];
 			} elseif ( in_array( $group, $this->no_mc_groups ) ) {
 				return false;
@@ -1269,8 +1273,10 @@ class WP_Object_Cache {
 			}
 		}
 
-		if ( Memcached::RES_SUCCESS === $this->getResultCode() )
+		if ( Memcached::RES_SUCCESS === $this->getResultCode() ) {
 			$this->add_to_internal_cache( $derived_key, $value );
+			$found = true;
+		}
 
 		return is_object( $value ) ? clone $value : $value;
 	}

--- a/tests/tests/test-all.php
+++ b/tests/tests/test-all.php
@@ -1138,6 +1138,88 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group ) );
 	}
 
+	public function test_get_by_key_value_with_found_indicator() {
+		$key = microtime();
+		$server_key = microtime();
+		$value = 'johansen';
+		$group = 'senators';
+		$found = false;
+
+		// Add string to memcached
+		$this->assertTrue( $this->object_cache->addByKey( $server_key, $key, $value, $group ) );
+
+		// Verify correct value is returned
+		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group, false, $found ) );
+
+		// Verify that found variable is set to true because the item was found
+		$this->assertTrue( $found );
+	}
+
+	public function test_get_by_key_value_with_found_indicator_when_value_is_not_found() {
+		$key = microtime();
+		$server_key = microtime();
+		$value = 'fisher';
+		$group = 'senators';
+		$found = false;
+
+		// Add string to memcached
+		$this->assertTrue( $this->object_cache->addByKey( $server_key, $key, $value, $group ) );
+
+		// Verify that the value is deleted
+		$this->assertTrue( $this->object_cache->deleteByKey( $server_key, $key, $group ) );
+
+		// Verify that false is returned
+		$this->assertFalse( $this->object_cache->getByKey( $server_key, $key, $group, false, $found ) );
+
+		// Verify that found variable is set to true because the item was found
+		$this->assertFalse( $found );
+	}
+
+	public function test_get_by_key_value_with_found_indicator_when_retrieved_from_memcached() {
+		$key = microtime();
+		$server_key = microtime();
+		$value = 'ovechkin';
+		$group = 'capitals';
+		$found = false;
+
+		// Add string to memcached
+		$this->assertTrue( $this->object_cache->addByKey( $server_key, $key, $value, $group ) );
+
+		// Remove from internal cache and verify
+		unset( $this->object_cache->cache[ $this->object_cache->buildKey( $key, $group ) ] );
+		$this->assertFalse( $this->object_cache->get_from_runtime_cache( $key, $group ) );
+
+		// Verify correct value is returned
+		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group, false, $found ) );
+
+		// Verify that found variable is set to true because the item was found
+		$this->assertTrue( $found );
+	}
+
+	public function test_get_by_key_value_with_found_indicator_when_retrieved_from_memcached_and_value_is_not_found() {
+		$key = microtime();
+		$server_key = microtime();
+		$value = 'simmonds';
+		$group = 'flyers';
+		$found = false;
+
+		// Add string to memcached
+		$this->assertTrue( $this->object_cache->addByKey( $server_key, $key, $value, $group ) );
+
+		// Remove from internal cache and verify
+		unset( $this->object_cache->cache[ $this->object_cache->buildKey( $key, $group ) ] );
+		$this->assertFalse( $this->object_cache->get_from_runtime_cache( $key, $group ) );
+
+		// Verify that the value is deleted
+		$this->assertTrue( $this->object_cache->deleteByKey( $server_key, $key, $group ) );
+
+		// Verify that false is returned
+		$this->assertFalse( $this->object_cache->getByKey( $server_key, $key, $group, false, $found ) );
+
+		// Verify that found variable is set to true because the item was found
+		$this->assertFalse( $found );
+	}
+
 	public function test_get_by_key_value_with_callback_with_true_response() {
 		$key = microtime();
 		$group = 'nj-devils';

--- a/tests/tests/test-all.php
+++ b/tests/tests/test-all.php
@@ -202,7 +202,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 	}
 
 	public function test_add_servers() {
-		$servers = array( array( '127.0.0.1', 11211, 1 ), array( 'trunkosaurus.dev', 11211, 1 ) );
+		$servers = array( array( '127.0.0.1', 11211, 1 ), array( '127.0.0.1', 11212, 1 ) );
 
 		// Add server
 		$this->assertTrue( $this->object_cache->addServers( $servers ) );

--- a/tests/tests/test-all.php
+++ b/tests/tests/test-all.php
@@ -831,6 +831,84 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$this->assertSame( $value, $this->object_cache->get( $key, $group ) );
 	}
 
+	public function test_get_value_with_found_indicator() {
+		$key = microtime();
+		$value = 'karlson';
+		$group = 'senators';
+		$found = false;
+
+		// Add string to memcached
+		$this->assertTrue( $this->object_cache->add( $key, $value, $group ) );
+
+		// Verify correct value is returned
+		$this->assertSame( $value, $this->object_cache->get( $key, $group, false, $found ) );
+
+		// Verify that found variable is set to true because the item was found
+		$this->assertTrue( $found );
+	}
+
+	public function test_get_value_with_found_indicator_when_value_is_not_found() {
+		$key = microtime();
+		$value = 'neil';
+		$group = 'senators';
+		$found = false;
+
+		// Add string to memcached
+		$this->assertTrue( $this->object_cache->add( $key, $value, $group ) );
+
+		// Verify that the value is deleted
+		$this->assertTrue( $this->object_cache->delete( $key, $group ) );
+
+		// Verify that false is returned
+		$this->assertFalse( $this->object_cache->get( $key, $group, false, $found ) );
+
+		// Verify that found variable is set to true because the item was found
+		$this->assertFalse( $found );
+	}
+
+	public function test_get_value_with_found_indicator_when_retrieved_from_memcached() {
+		$key = microtime();
+		$value = 'holtby';
+		$group = 'capitals';
+		$found = false;
+
+		// Add string to memcached
+		$this->assertTrue( $this->object_cache->add( $key, $value, $group ) );
+
+		// Remove from internal cache and verify
+		unset( $this->object_cache->cache[ $this->object_cache->buildKey( $key, $group ) ] );
+		$this->assertFalse( $this->object_cache->get_from_runtime_cache( $key, $group ) );
+
+		// Verify correct value is returned
+		$this->assertSame( $value, $this->object_cache->get( $key, $group, false, $found ) );
+
+		// Verify that found variable is set to true because the item was found
+		$this->assertTrue( $found );
+	}
+
+	public function test_get_value_with_found_indicator_when_retrieved_from_memcached_and_value_is_not_found() {
+		$key = microtime();
+		$value = 'backstrom';
+		$group = 'capitals';
+		$found = false;
+
+		// Add string to memcached
+		$this->assertTrue( $this->object_cache->add( $key, $value, $group ) );
+
+		// Remove from internal cache and verify
+		unset( $this->object_cache->cache[ $this->object_cache->buildKey( $key, $group ) ] );
+		$this->assertFalse( $this->object_cache->get_from_runtime_cache( $key, $group ) );
+
+		// Verify that the value is deleted
+		$this->assertTrue( $this->object_cache->delete( $key, $group ) );
+
+		// Verify that false is returned
+		$this->assertFalse( $this->object_cache->get( $key, $group, false, $found ) );
+
+		// Verify that found variable is set to true because the item was found
+		$this->assertFalse( $found );
+	}
+
 	public function test_get_value_with_callback_with_true_response() {
 		$key = microtime();
 		$group = 'nj-devils';

--- a/tests/tests/test-all.php
+++ b/tests/tests/test-all.php
@@ -407,7 +407,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$this->assertTrue( $this->object_cache->add( $key, $value ) );
 
 		// Get CAS token
-		$this->assertSame( $value, $this->object_cache->get( $key, 'default', '', false, null, $cas_token ) );
+		$this->assertSame( $value, $this->object_cache->get( $key, 'default', false, $found, '', false, null, $cas_token ) );
 
 		// Verify that we have a CAS token
 		$this->assertTrue( is_float( $cas_token ) );
@@ -430,7 +430,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 
 		// Get CAS token
 		$cas_token = '';
-		$this->assertSame( $value, $this->object_cache->get( $key, 'default', '', false, null, $cas_token ) );
+		$this->assertSame( $value, $this->object_cache->get( $key, 'default', false, $found, '', false, null, $cas_token ) );
 
 		// Verify that we have a CAS token
 		$this->assertTrue( is_float( $cas_token ) );
@@ -838,7 +838,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$value = 'brodeur';
 
 		// Verify that callback sets value correctly
-		$this->assertSame( $value, $this->object_cache->get( $key, $group, '', true, 'memcached_get_callback_true' ) );
+		$this->assertSame( $value, $this->object_cache->get( $key, $group, false, $found, '', true, 'memcached_get_callback_true' ) );
 
 		// Doublecheck it
 		$this->assertSame( $value, $this->object_cache->get( $key, $group ) );
@@ -851,7 +851,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$value = 'brodeur';
 
 		// Verify that callback sets value correctly
-		$this->assertFalse( $this->object_cache->get( $key, $group, '', false, 'memcached_get_callback_false' ) );
+		$this->assertFalse( $this->object_cache->get( $key, $group, false, $found, '', false, 'memcached_get_callback_false' ) );
 
 		// Doublecheck it
 		$this->assertFalse( $this->object_cache->get( $key, $group ) );
@@ -864,7 +864,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$value = 'brodeur';
 
 		// Verify that callback sets value correctly
-		$this->assertSame( $value, $this->object_cache->get( $key, $group, '', false, array( &$this, 'memcached_get_callback_true_class_method' ) ) );
+		$this->assertSame( $value, $this->object_cache->get( $key, $group, false, $found, '', false, array( &$this, 'memcached_get_callback_true_class_method' ) ) );
 
 		// Doublecheck it
 		$this->assertSame( $value, $this->object_cache->get( $key, $group ) );
@@ -880,7 +880,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$group = 'nhl-nj-devils-team-runner-up';
 
 		// Verify that callback sets value correctly
-		$this->assertFalse( $this->object_cache->get( $key, $group, '', false, array( &$this, 'memcached_get_callback_false_class_method' ) ) );
+		$this->assertFalse( $this->object_cache->get( $key, $group, false, $found, '', false, array( &$this, 'memcached_get_callback_false_class_method' ) ) );
 
 		// Doublecheck it
 		$this->assertFalse( $this->object_cache->get( $key, $group ) );
@@ -898,14 +898,14 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$value = 'brodeur';
 
 		// Verify that if completely bypassed
-		$this->assertFalse( $this->object_cache->get( $key, $group, '', false, array( &$this, 'memcached_get_callback_true_no_mc_group' ) ) );
+		$this->assertFalse( $this->object_cache->get( $key, $group, false, $found, '', false, array( &$this, 'memcached_get_callback_true_no_mc_group' ) ) );
 
 		// Doublecheck that no value has been set
 		$this->assertFalse( $this->object_cache->get( $key, $group ) );
 
 		// Verify that a normal set and get works when a callback is sent
 		$this->assertTrue( $this->object_cache->set( $key, $value, $group ) );
-		$this->assertSame( $value, $this->object_cache->get( $key, $group, '', false, array( &$this, 'memcached_get_callback_true_no_mc_group' ) ) );
+		$this->assertSame( $value, $this->object_cache->get( $key, $group, false, $found, '', false, array( &$this, 'memcached_get_callback_true_no_mc_group' ) ) );
 	}
 
 	public function memcached_get_callback_true_no_mc_group( $m, $key, &$value ) {
@@ -923,7 +923,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$this->assertTrue( $this->object_cache->add( $key, $value ) );
 
 		// Get CAS token
-		$this->assertSame( $value, $this->object_cache->get( $key, 'default', '', false, null, $cas_token ) );
+		$this->assertSame( $value, $this->object_cache->get( $key, 'default', false, $found, '', false, null, $cas_token ) );
 
 		// Verify that we have a CAS token
 		$this->assertTrue( is_float( $cas_token ) );
@@ -939,7 +939,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$key = microtime();
 
 		// Return false with value not yet set
-		$this->assertFalse( $this->object_cache->get( $key, 'default', '', false, null, $cas_token ) );
+		$this->assertFalse( $this->object_cache->get( $key, 'default', false, $found, '', false, null, $cas_token ) );
 
 		// Verify that we have a CAS token
 		$this->assertTrue( is_null( $cas_token ) );
@@ -952,7 +952,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$group = 'devils';
 
 		// Set value via the callback when key is not set
-		$this->assertSame( $value, $this->object_cache->get( $key, $group, '', false, array( &$this, 'memcached_get_callback_for_cas_token_and_callback' ), $cas_token ) );
+		$this->assertSame( $value, $this->object_cache->get( $key, $group, false, $found, '', false, array( &$this, 'memcached_get_callback_for_cas_token_and_callback' ), $cas_token ) );
 
 		// Double check the value
 		$this->assertSame( $value, $this->object_cache->get( $key, $group ) );
@@ -961,7 +961,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$this->assertTrue( (float) 0 === $cas_token );
 
 		// The value should now be set and this function should return the same result
-		$this->assertSame( $value, $this->object_cache->get( $key, $group, '', false, array( &$this, 'memcached_get_callback_for_cas_token_and_callback' ), $cas_token ) );
+		$this->assertSame( $value, $this->object_cache->get( $key, $group, false, $found, '', false, array( &$this, 'memcached_get_callback_for_cas_token_and_callback' ), $cas_token ) );
 
 		// See if we got an acceptable CAS token
 		$this->assertTrue( is_float( $cas_token ) && $cas_token > 0 );
@@ -982,7 +982,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$group = 'devils';
 
 		// Set value via the callback when key is not set
-		$this->assertSame( $value, $this->object_cache->get( $key, $group, '', false, array( &$this, 'fake_function' ) ) );
+		$this->assertSame( $value, $this->object_cache->get( $key, $group, false, $found, '', false, array( &$this, 'fake_function' ) ) );
 
 	}
 

--- a/tests/tests/test-all.php
+++ b/tests/tests/test-all.php
@@ -458,7 +458,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 
 		// Get CAS token
 		$cas_token = '';
-		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, 'default', null, $cas_token ) );
+		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, 'default', false, $found, null, $cas_token ) );
 
 		// Verify that we have a CAS token
 		$this->assertTrue( is_float( $cas_token ) );
@@ -483,7 +483,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 
 		// Get CAS token
 		$cas_token = '';
-		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, 'default', null, $cas_token ) );
+		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, 'default', false, $found, null, $cas_token ) );
 
 		// Verify that we have a CAS token
 		$this->assertTrue( is_float( $cas_token ) );
@@ -1069,7 +1069,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$server_key = microtime();
 
 		// Verify that callback sets value correctly
-		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group, 'memcached_get_callback_true' ) );
+		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group, false, $found, 'memcached_get_callback_true' ) );
 
 		// Doublecheck it
 		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group ) );
@@ -1082,7 +1082,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$server_key = microtime();
 
 		// Verify that callback sets value correctly
-		$this->assertFalse( $this->object_cache->getByKey( $server_key, $key, $group, 'memcached_get_callback_false' ) );
+		$this->assertFalse( $this->object_cache->getByKey( $server_key, $key, $group, false, $found, 'memcached_get_callback_false' ) );
 
 		// Doublecheck it
 		$this->assertFalse( $this->object_cache->getByKey( $server_key, $key, $group ) );
@@ -1097,7 +1097,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$server_key = microtime();
 
 		// Verify that callback sets value correctly
-		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group, array( &$this, 'memcached_get_callback_true_class_method' ) ) );
+		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group, false, $found, array( &$this, 'memcached_get_callback_true_class_method' ) ) );
 
 		// Doublecheck it
 		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group ) );
@@ -1110,7 +1110,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$server_key = microtime();
 
 		// Verify that callback sets value correctly
-		$this->assertFalse( $this->object_cache->getByKey( $server_key, $key, $group, array( &$this, 'memcached_get_callback_false_class_method' ) ) );
+		$this->assertFalse( $this->object_cache->getByKey( $server_key, $key, $group, false, $found, array( &$this, 'memcached_get_callback_false_class_method' ) ) );
 
 		// Doublecheck it
 		$this->assertFalse( $this->object_cache->getByKey( $server_key, $key, $group ) );
@@ -1125,14 +1125,14 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$server_key = microtime();
 
 		// Verify that if completely bypassed
-		$this->assertFalse( $this->object_cache->getByKey( $server_key, $key, $group, array( &$this, 'memcached_get_callback_true_no_mc_group' ) ) );
+		$this->assertFalse( $this->object_cache->getByKey( $server_key, $key, $group, false, $found, array( &$this, 'memcached_get_callback_true_no_mc_group' ) ) );
 
 		// Doublecheck that no value has been set
 		$this->assertFalse( $this->object_cache->getByKey( $server_key, $key, $group ) );
 
 		// Verify that a normal set and get works when a callback is sent
 		$this->assertTrue( $this->object_cache->setByKey( $server_key, $key, $value, $group ) );
-		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group, array( &$this, 'memcached_get_callback_true_no_mc_group' ) ) );
+		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group, false, $found, array( &$this, 'memcached_get_callback_true_no_mc_group' ) ) );
 	}
 
 	public function test_get_by_value_value_and_return_cas_token() {
@@ -1147,7 +1147,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$this->assertTrue( $this->object_cache->addByKey( $server_key, $key, $value ) );
 
 		// Get CAS token
-		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, 'default', null, $cas_token ) );
+		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, 'default', false, $found, null, $cas_token ) );
 
 		// Verify that we have a CAS token
 		$this->assertTrue( is_float( $cas_token ) );
@@ -1165,7 +1165,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$server_key = microtime();
 
 		// Return false with value not yet set
-		$this->assertFalse( $this->object_cache->getByKey( $server_key, $key, 'default', null, $cas_token ) );
+		$this->assertFalse( $this->object_cache->getByKey( $server_key, $key, 'default', false, $found, null, $cas_token ) );
 
 		// Verify that we have a CAS token
 		$this->assertTrue( is_null( $cas_token ) );
@@ -1180,7 +1180,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$server_key = 'devils';
 
 		// Set value via the callback when key is not set
-		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group, array( &$this, 'memcached_get_callback_for_cas_token_and_callback' ), $cas_token ) );
+		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group, false, $found, array( &$this, 'memcached_get_callback_for_cas_token_and_callback' ), $cas_token ) );
 
 		// Since not received from memcached, cas_token should be (float) 0
 		$this->assertTrue( (float) 0 === $cas_token );
@@ -1189,7 +1189,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group ) );
 
 		// The value should now be set and this function should return the same result
-		$result = $this->object_cache->getByKey( $server_key, $key, $group, array( &$this, 'memcached_get_callback_for_cas_token_and_callback' ), $cas_token2 );
+		$result = $this->object_cache->getByKey( $server_key, $key, $group, false, $found, array( &$this, 'memcached_get_callback_for_cas_token_and_callback' ), $cas_token2 );
 		$this->assertSame( $value, $result );
 
 		// See if we got an acceptable CAS token
@@ -1208,7 +1208,7 @@ class MemcachedUnitTests extends WP_UnitTestCase {
 		$server_key = microtime();
 
 		// Set value via the callback when key is not set
-		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group, array( &$this, 'fake_function' ) ) );
+		$this->assertSame( $value, $this->object_cache->getByKey( $server_key, $key, $group, false, $found, array( &$this, 'fake_function' ) ) );
 	}
 
 	public function test_get_delayed_returns_correct_values() {


### PR DESCRIPTION
With php-fpm 5.5.3 and memcached 1.4.14 I'm seeing the following warning several times per request on WordPress 3.8.1:

```
PHP message: PHP Warning:  Memcached::get() expects parameter 2 to be a valid callback, no array or string given in /usr/share/wordpress/wp-content/object-cache.php on line 1262
```
