### PR TITLE
Expiry Times

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -1060,9 +1060,9 @@ class WP_Object_Cache {
 
 		// Save to Memcached
 		if ( $byKey )
-			$result = $this->m->casByKey( $cas_token, $server_key, $derived_key, $value, absint( $expiration ) );
+			$result = $this->m->casByKey( $cas_token, $server_key, $derived_key, $value, $expiration );
 		else
-			$result = $this->m->cas( $cas_token, $derived_key, $value, absint( $expiration ) );
+			$result = $this->m->cas( $cas_token, $derived_key, $value, $expiration );
 
 		// Store in runtime cache if cas was successful
 		if ( Memcached::RES_SUCCESS === $this->getResultCode() )

--- a/object-cache.php
+++ b/object-cache.php
@@ -873,6 +873,7 @@ class WP_Object_Cache {
 		}
 
 		$derived_key = $this->buildKey( $key, $group );
+		$expiration  = $this->sanitize_expiration( $expiration );
 
 		// If group is a non-Memcached group, save to runtime cache, not Memcached
 		if ( in_array( $group, $this->no_mc_groups ) ) {
@@ -1047,6 +1048,7 @@ class WP_Object_Cache {
 	 */
 	public function cas( $cas_token, $key, $value, $group = 'default', $expiration = 0, $server_key = '', $byKey = false ) {
 		$derived_key = $this->buildKey( $key, $group );
+		$expiration  = $this->sanitize_expiration( $expiration );
 
 		/**
 		 * If group is a non-Memcached group, save to runtime cache, not Memcached. Note
@@ -1699,6 +1701,7 @@ class WP_Object_Cache {
 	 */
 	public function replace( $key, $value, $group = 'default', $expiration = 0, $server_key = '', $byKey = false ) {
 		$derived_key = $this->buildKey( $key, $group );
+		$expiration  = $this->sanitize_expiration( $expiration );
 
 		// If group is a non-Memcached group, save to runtime cache, not Memcached
 		if ( in_array( $group, $this->no_mc_groups ) ) {
@@ -1760,6 +1763,7 @@ class WP_Object_Cache {
 	 */
 	public function set( $key, $value, $group = 'default', $expiration = 0, $server_key = '', $byKey = false ) {
 		$derived_key = $this->buildKey( $key, $group );
+		$expiration  = $this->sanitize_expiration( $expiration );
 
 		// If group is a non-Memcached group, save to runtime cache, not Memcached
 		if ( in_array( $group, $this->no_mc_groups ) ) {
@@ -1819,7 +1823,8 @@ class WP_Object_Cache {
 	 */
 	public function setMulti( $items, $groups = 'default', $expiration = 0, $server_key = '', $byKey = false ) {
 		// Build final keys and replace $items keys with the new keys
-		$derived_keys = $this->buildKeys( array_keys( $items ), $groups );
+		$derived_keys  = $this->buildKeys( array_keys( $items ), $groups );
+		$expiration    = $this->sanitize_expiration( $expiration );
 		$derived_items = array_combine( $derived_keys, $items );
 
 		// Do not add to memcached if in no_mc_groups

--- a/object-cache.php
+++ b/object-cache.php
@@ -1603,7 +1603,7 @@ class WP_Object_Cache {
 	 * @param   string      $group      The group value appended to the $key.
 	 * @return  int|bool                Returns item's new value on success or FALSE on failure.
 	 */
-	public function incr(  $key, $offset = 1, $group = 'default' ) {
+	public function incr( $key, $offset = 1, $group = 'default' ) {
 		return $this->increment( $key, $offset, $group );
 	}
 

--- a/object-cache.php
+++ b/object-cache.php
@@ -1713,9 +1713,9 @@ class WP_Object_Cache {
 
 		// Save to Memcached
 		if ( $byKey )
-			$result = $this->m->replaceByKey( $server_key, $derived_key, $value, absint( $expiration ) );
+			$result = $this->m->replaceByKey( $server_key, $derived_key, $value, $expiration );
 		else
-			$result = $this->m->replace( $derived_key, $value, absint( $expiration ) );
+			$result = $this->m->replace( $derived_key, $value, $expiration );
 
 		// Store in runtime cache if add was successful
 		if ( Memcached::RES_SUCCESS === $this->getResultCode() )
@@ -1769,9 +1769,9 @@ class WP_Object_Cache {
 
 		// Save to Memcached
 		if ( $byKey ) {
-			$result = $this->m->setByKey( $server_key, $derived_key, $value, absint( $expiration ) );
+			$result = $this->m->setByKey( $server_key, $derived_key, $value, $expiration );
 		} else {
-			$result = $this->m->set( $derived_key, $value, absint( $expiration ) );
+			$result = $this->m->set( $derived_key, $value, $expiration );
 		}
 
 		// Store in runtime cache if add was successful
@@ -1837,9 +1837,9 @@ class WP_Object_Cache {
 
 		// Save to memcached
 		if ( $byKey )
-			$result = $this->m->setMultiByKey( $server_key, $derived_items, absint( $expiration ) );
+			$result = $this->m->setMultiByKey( $server_key, $derived_items, $expiration );
 		else
-			$result = $this->m->setMulti( $derived_items, absint( $expiration ) );
+			$result = $this->m->setMulti( $derived_items, $expiration );
 
 		// Store in runtime cache if add was successful
 		if ( Memcached::RES_SUCCESS === $this->getResultCode() )

--- a/tests/tests/cas.php
+++ b/tests/tests/cas.php
@@ -101,4 +101,66 @@ class MemcachedUnitTestsCAS extends MemcachedUnitTests {
 		// Verify the internal cache is correctly set
 		$this->assertSame( $new_value, $this->object_cache->cache[ $this->object_cache->buildKey( $key ) ] );
 	}
+
+	public function test_cas_with_expiration_of_30_days() {
+		$key = 'usa';
+		$value = 'merica';
+		$group = 'july';
+		$value2 = 'dutch';
+		$built_key = $this->object_cache->buildKey( $key, $group );
+		$found = false;
+		$cas_token = '';
+
+		// 30 days
+		$expiration = 60 * 60 * 24 * 30;
+
+		$this->assertTrue( $this->object_cache->set( $key, $value, $group, $expiration ) );
+		$this->assertSame( $value, $this->object_cache->get( $key, $group, false, $found, '', false, null, $cas_token ) );
+
+		// Set a new value with the CAS method
+		$this->assertTrue( $this->object_cache->cas( $cas_token, $key, $value2, $group, $expiration ) );
+
+		// Verify that the value is in cache by accessing memcached directly
+		$this->assertEquals( $value2, $this->object_cache->m->get( $built_key ) );
+
+		// Remove the value from internal cache to force a lookup
+		unset( $this->object_cache->cache[ $built_key ] );
+
+		// Verify that the value is no longer in the internal cache
+		$this->assertFalse( $this->object_cache->get_from_runtime_cache( $key, $group ) );
+
+		// Do the lookup with the API to verify that we get the value
+		$this->assertEquals( $value2, $this->object_cache->get( $key, $group ) );
+	}
+
+	public function test_cas_with_expiration_longer_than_30_days() {
+		$key = 'usa';
+		$value = 'merica';
+		$group = 'july';
+		$value2 = 'dutch';
+		$built_key = $this->object_cache->buildKey( $key, $group );
+		$found = false;
+		$cas_token = '';
+
+		// 30 days and 1 second; if interpreted as timestamp, becomes "Sat, 31 Jan 1970 00:00:01 GMT"
+		$expiration = 60 * 60 * 24 * 30 + 1;
+
+		$this->assertTrue( $this->object_cache->set( $key, $value, $group, $expiration ) );
+		$this->assertSame( $value, $this->object_cache->get( $key, $group, false, $found, '', false, null, $cas_token ) );
+
+		// Set a new value with the CAS method
+		$this->assertTrue( $this->object_cache->cas( $cas_token, $key, $value2, $group, $expiration ) );
+
+		// Verify that the value is in cache by accessing memcached directly
+		$this->assertEquals( $value2, $this->object_cache->m->get( $built_key ) );
+
+		// Remove the value from internal cache to force a lookup
+		unset( $this->object_cache->cache[ $built_key ] );
+
+		// Verify that the value is no longer in the internal cache
+		$this->assertFalse( $this->object_cache->get_from_runtime_cache( $key, $group ) );
+
+		// Do the lookup with the API to verify that we get the value
+		$this->assertEquals( $value2, $this->object_cache->get( $key, $group ) );
+	}
 }

--- a/tests/tests/other.php
+++ b/tests/tests/other.php
@@ -153,4 +153,24 @@ class MemcachedUnitTestsAll extends MemcachedUnitTests {
 		$this->object_cache->switch_to_blog( get_current_blog_id() );
 		$this->assertEquals( $val2, $this->object_cache->get( $key, 'global-cache-test' ) );
 	}
+
+	public function test_sanitize_expiration_leaves_value_untouched_if_less_than_thirty_days() {
+		$time = 5;
+		$this->assertEquals( $time, $this->object_cache->sanitize_expiration( $time ) );
+	}
+
+	public function test_sanitize_expiration_leaves_value_untouched_if_exactly_thirty_days() {
+		$time = 60 * 60 * 24 * 30;
+		$this->assertEquals( $time, $this->object_cache->sanitize_expiration( $time ) );
+	}
+
+	public function test_sanitize_expiration_should_adjust_expiration_if_later_than_now() {
+		$time = 60 * 60 * 24 * 31;
+		$now = time();
+
+		// We need to manually set the internal timer to make sure we get the right value in testing
+		$this->object_cache->now = $now;
+
+		$this->assertEquals( $time + $now, $this->object_cache->sanitize_expiration( $time ) );
+	}
 }

--- a/tests/tests/replace.php
+++ b/tests/tests/replace.php
@@ -97,7 +97,7 @@ class MemcachedUnitTestsReplace extends MemcachedUnitTests {
 		$this->assertTrue( $this->object_cache->replace( $key, $value2, $group, $expiration ) );
 
 		// Verify that the value is in cache by accessing memcached directly
-		$this->assertEquals( $value, $this->object_cache->m->get( $built_key ) );
+		$this->assertEquals( $value2, $this->object_cache->m->get( $built_key ) );
 
 		// Remove the value from internal cache to force a lookup
 		unset( $this->object_cache->cache[ $built_key ] );

--- a/tests/tests/replace.php
+++ b/tests/tests/replace.php
@@ -54,4 +54,58 @@ class MemcachedUnitTestsReplace extends MemcachedUnitTests {
 
 		$this->assertFalse( $this->object_cache->getByKey( $server_key, $key ) );
 	}
+
+	public function test_replace_with_expiration_of_30_days() {
+		$key = 'usa';
+		$value = 'merica';
+		$group = 'july';
+		$built_key = $this->object_cache->buildKey( $key, $group );
+
+		$value2 = 'belgium';
+
+		// 30 days
+		$expiration = 60 * 60 * 24 * 30;
+
+		$this->assertTrue( $this->object_cache->set( $key, $value, $group ) );
+		$this->assertTrue( $this->object_cache->replace( $key, $value2, $group, $expiration ) );
+
+		// Verify that the value is in cache by accessing memcached directly
+		$this->assertEquals( $value2, $this->object_cache->m->get( $built_key ) );
+
+		// Remove the value from internal cache to force a lookup
+		unset( $this->object_cache->cache[ $built_key ] );
+
+		// Verify that the value is no longer in the internal cache
+		$this->assertFalse( $this->object_cache->get_from_runtime_cache( $key, $group ) );
+
+		// Do the lookup with the API to verify that we get the value
+		$this->assertEquals( $value2, $this->object_cache->get( $key, $group ) );
+	}
+
+	public function test_replace_with_expiration_longer_than_30_days() {
+		$key = 'usa';
+		$value = 'merica';
+		$group = 'july';
+		$built_key = $this->object_cache->buildKey( $key, $group );
+
+		$value2 = 'belgium';
+
+		// 30 days and 1 second; if interpreted as timestamp, becomes "Sat, 31 Jan 1970 00:00:01 GMT"
+		$expiration = 60 * 60 * 24 * 30 + 1;
+
+		$this->assertTrue( $this->object_cache->set( $key, $value, $group ) );
+		$this->assertTrue( $this->object_cache->replace( $key, $value2, $group, $expiration ) );
+
+		// Verify that the value is in cache by accessing memcached directly
+		$this->assertEquals( $value, $this->object_cache->m->get( $built_key ) );
+
+		// Remove the value from internal cache to force a lookup
+		unset( $this->object_cache->cache[ $built_key ] );
+
+		// Verify that the value is no longer in the internal cache
+		$this->assertFalse( $this->object_cache->get_from_runtime_cache( $key, $group ) );
+
+		// Do the lookup with the API to verify that we get the value
+		$this->assertEquals( $value2, $this->object_cache->get( $key, $group ) );
+	}
 }

--- a/tests/tests/set.php
+++ b/tests/tests/set.php
@@ -419,7 +419,7 @@ class MemcachedUnitTestsSet extends MemcachedUnitTests {
 		$group = 'july';
 		$built_key = $this->object_cache->buildKey( $key, $group );
 
-		// 30 days and 1 second; if interpreted as timestamp, becomes "Sat, 31 Jan 1970 00:00:01 GMT"
+		// 30 days
 		$expiration = 60 * 60 * 24 * 30;
 
 		$this->assertTrue( $this->object_cache->set( $key, $value, $group, $expiration ) );

--- a/tests/tests/set.php
+++ b/tests/tests/set.php
@@ -412,4 +412,52 @@ class MemcachedUnitTestsSet extends MemcachedUnitTests {
 			}
 		}
 	}
+
+	public function test_set_with_expiration_of_30_days() {
+		$key = 'usa';
+		$value = 'merica';
+		$group = 'july';
+		$built_key = $this->object_cache->buildKey( $key, $group );
+
+		// 30 days and 1 second; if interpreted as timestamp, becomes "Sat, 31 Jan 1970 00:00:01 GMT"
+		$expiration = 60 * 60 * 24 * 30;
+
+		$this->assertTrue( $this->object_cache->set( $key, $value, $group, $expiration ) );
+
+		// Verify that the value is in cache by accessing memcached directly
+		$this->assertEquals( $value, $this->object_cache->m->get( $built_key ) );
+
+		// Remove the value from internal cache to force a lookup
+		unset( $this->object_cache->cache[ $built_key ] );
+
+		// Verify that the value is no longer in the internal cache
+		$this->assertFalse( $this->object_cache->get_from_runtime_cache( $key, $group ) );
+
+		// Do the lookup with the API to verify that we get the value
+		$this->assertEquals( $value, $this->object_cache->get( $key, $group ) );
+	}
+
+	public function test_set_with_expiration_longer_than_30_days() {
+		$key = 'usa';
+		$value = 'merica';
+		$group = 'july';
+		$built_key = $this->object_cache->buildKey( $key, $group );
+
+		// 30 days and 1 second; if interpreted as timestamp, becomes "Sat, 31 Jan 1970 00:00:01 GMT"
+		$expiration = 60 * 60 * 24 * 30 + 1;
+
+		$this->assertTrue( $this->object_cache->set( $key, $value, $group, $expiration ) );
+
+		// Verify that the value is in cache
+		$this->assertEquals( $value, $this->object_cache->m->get( $built_key ) );
+
+		// Remove the value from internal cache to force a lookup
+		unset( $this->object_cache->cache[ $built_key ] );
+
+		// Verify that the value is no longer in the internal cache
+		$this->assertFalse( $this->object_cache->get_from_runtime_cache( $key, $group ) );
+
+		// Do the lookup with the API to verify that we get the value
+		$this->assertEquals( $value, $this->object_cache->get( $key, $group ) );
+	}
 }

--- a/tests/tests/set.php
+++ b/tests/tests/set.php
@@ -460,4 +460,68 @@ class MemcachedUnitTestsSet extends MemcachedUnitTests {
 		// Do the lookup with the API to verify that we get the value
 		$this->assertEquals( $value, $this->object_cache->get( $key, $group ) );
 	}
+
+	public function test_set_multi_with_expiration_of_30_days() {
+		$values = array(
+			'header' => 'footer',
+			'goal'   => 'save',
+			'fast'   => 'slow',
+		);
+
+		$group = 'CRC';
+
+		// 30 days
+		$expiration = 60 * 60 * 24 * 30;
+
+		$this->assertTrue( $this->object_cache->setMulti( $values, $group, $expiration ) );
+
+		// Verify values independently
+		foreach ( $values as $key => $value ) {
+			$built_key = $this->object_cache->buildKey( $key, $group );
+
+			// Verify that the value is in cache by accessing memcached directly
+			$this->assertSame( $value, $this->object_cache->m->get( $built_key ) );
+
+			// Remove the value from internal cache to force a lookup
+			unset( $this->object_cache->cache[ $built_key ] );
+
+			// Verify that the value is no longer in the internal cache
+			$this->assertFalse( $this->object_cache->get_from_runtime_cache( $key, $group ) );
+
+			// Do the lookup with the API to verify that we get the value
+			$this->assertEquals( $value, $this->object_cache->get( $key, $group ) );
+		}
+	}
+
+	public function test_set_multi_with_expiration_longer_than_30_days() {
+		$values = array(
+			'header' => 'footer',
+			'goal'   => 'save',
+			'fast'   => 'slow',
+		);
+
+		$group = 'CRC';
+
+		// 30 days and 1 second; if interpreted as timestamp, becomes "Sat, 31 Jan 1970 00:00:01 GMT"
+		$expiration = 60 * 60 * 24 * 30 + 1;
+
+		$this->assertTrue( $this->object_cache->setMulti( $values, $group, $expiration ) );
+
+		// Verify values independently
+		foreach ( $values as $key => $value ) {
+			$built_key = $this->object_cache->buildKey( $key, $group );
+
+			// Verify that the value is in cache by accessing memcached directly
+			$this->assertSame( $value, $this->object_cache->m->get( $built_key ) );
+
+			// Remove the value from internal cache to force a lookup
+			unset( $this->object_cache->cache[ $built_key ] );
+
+			// Verify that the value is no longer in the internal cache
+			$this->assertFalse( $this->object_cache->get_from_runtime_cache( $key, $group ) );
+
+			// Do the lookup with the API to verify that we get the value
+			$this->assertEquals( $value, $this->object_cache->get( $key, $group ) );
+		}
+	}
 }


### PR DESCRIPTION
To handle expiry times over 30 days, +time() needs to be added to the expiry when setting it in $this->m->add...

I think it should be handled in this drop-in because APC and other cache handlers do not have this limitation. Therefore adding time() in a theme/plugin when using wp_set_cache() would add ~44 years to all expiries on other cache systems.

Fortunately you can add time() to expiries that are any length because it's meant to handle them all, event time()+0 would work fine. so a blanket fix can be applied.

I'll try to find the time() to make a pull request.

Read more: http://www.php.net/manual/en/memcached.expiration.php
