### PR TITLE
Make sure that wp_suspend_cache_addition is defined before calling...

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -868,7 +868,13 @@ class WP_Object_Cache {
 	 * @return  bool                        Returns TRUE on success or FALSE on failure.
 	 */
 	public function add( $key, $value, $group = 'default', $expiration = 0, $server_key = '', $byKey = false ) {
-		if ( wp_suspend_cache_addition() ) {
+		/*
+		 * Ensuring that wp_suspend_cache_addition is defined before calling, because sometimes an advanced-cache.php
+		 * file will load object-cache.php before wp-includes/functions.php is loaded. In those cases, if wp_cache_add
+		 * is called in advanced-cache.php before any more of WordPress is loaded, we get a fatal error because
+		 * wp_suspend_cache_addition will not be defined until wp-includes/functions.php is loaded.
+		 */
+		if ( function_exists( 'wp_suspend_cache_addition' ) && wp_suspend_cache_addition() ) {
 			return false;
 		}
 


### PR DESCRIPTION
...the function, to avoid fatal errors where object-cache.php might be loaded by advanced-cache.php (prior to wp_suspend_cache_addition being defined)

Fixes #44 
