### PR TITLE
Add plugin information block

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -1,4 +1,13 @@
 <?php
+/*
+Plugin Name: WordPress pecl memcached object cache
+Description: The real Memcached (not Memcache) backend for the WP Object Cache.
+Version:
+Plugin URI: https://github.com/tollmanz/wordpress-pecl-memcached-object-cache
+Author: Zack Tollman
+Author URI: http://tollmanz.com/
+*/
+
 /**
  * Adds a value to cache.
  *


### PR DESCRIPTION
G'day, this adds the basic plugin information block. It helps identify _which_ Memcache(d) object cache is installed on a given website, and provides links to the author's website and the GitHub project. vis:

![drop-ins](https://cloud.githubusercontent.com/assets/1294614/5039284/fca55daa-6bef-11e4-8aef-569213d9df5c.png)
