### PR TITLE
Set license to MIT

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,3 +175,27 @@ php > echo $m->get( 'foo' ) . "\n";
 
 * Zack Tollman
 * 10up
+
+## License
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Zack Tollman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/pecl-memcached.php
+++ b/src/pecl-memcached.php
@@ -6,8 +6,27 @@
  * Version:        1.0.0.
  * Author:         Zack Tollman
  * Author URI:     http://tollmanz.com
- * License:        GPLv2 or later
- * License URI:    http://www.gnu.org/licenses/gpl-2.0.html
+ * License:        MIT
+ *
+ *                 Copyright (c) 2013 Zack Tollman
+
+ *                 Permission is hereby granted, free of charge, to any person obtaining a copy
+ *                 of this software and associated documentation files (the "Software"), to deal
+ *                 in the Software without restriction, including without limitation the rights
+ *                 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *                 copies of the Software, and to permit persons to whom the Software is
+ *                 furnished to do so, subject to the following conditions:
+ *
+ *                 The above copyright notice and this permission notice shall be included in all
+ *                 copies or substantial portions of the Software.
+ *
+ *                 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *                 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *                 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *                 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *                 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *                 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *                 SOFTWARE.
  */
 
 if ( ! class_exists( 'ZDT_PECL_Memcached_Object_Cache' ) ) :

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -5,8 +5,7 @@ Tags: performance, object cache, drop-in
 Requires at least: 3.4
 Tested up to: 3.9.1
 Stable tag: 1.0.0
-License: GPLv2 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
+License: MIT
 
 Object cache drop-in using the Memcached PECL extension to interface with Memcached.
 


### PR DESCRIPTION
After having agreed on the MIT license ( #63 ) for the project, I am changing the license to MIT. Note that there was some indication in the develop branch that I was going to license it as GPLv2; however, this was just copied from plugin boilerplate and was never seriously considered.
