### PR TITLE
Add branch aliases to composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,11 @@
   },
   "require": {
     "php": ">=5.3"
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "1.0.x-dev",
+      "dev-develop": "2.0.x-dev"
+    }
   }
 }


### PR DESCRIPTION
In lieu of proper tags, having branch aliases in composer will
make it simpler for consumers to pull the right code into their
projects.

Currently, I'm setting "dev-master" as the "1.0.x" release and
"dev-develop" as the "2.0.x" release. This should allow for a
seamless update when I start tagging with the 2.0.0 release.
