### PR TITLE
Fix Travis badge and proper readme file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/tollmanz/wordpress-memcached-backend.png?branch=master)](https://travis-ci.org/tollmanz/wordpress-memcached-backend)
+[![Build Status](https://travis-ci.org/tollmanz/wordpress-pecl-memcached-object-cache.png?branch=master)](https://travis-ci.org/tollmanz/wordpress-pecl-memcached-object-cache)
 
 ## Overview
 


### PR DESCRIPTION
The project name changed but not the badge in the README.