### PR TITLE
Fix: Multiple warnings when Memcached off

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ php:
 env:
     - WP_VERSION=latest WP_MULTISITE=0
     - WP_VERSION=latest WP_MULTISITE=1
-    - WP_VERSION=3.9.1 WP_MULTISITE=0
-    - WP_VERSION=3.9.1 WP_MULTISITE=1
-    - WP_VERSION=3.8.3 WP_MULTISITE=0
-    - WP_VERSION=3.8.3 WP_MULTISITE=1
 
 before_script:
     - bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION

--- a/object-cache.php
+++ b/object-cache.php
@@ -278,8 +278,13 @@ function wp_cache_fetch_all() {
  * @param int       $delay  Number of seconds to wait before invalidating the items.
  * @return bool             Returns TRUE on success or FALSE on failure.
  */
-function wp_cache_flush( $delay = 0 ) {	
-	$caller = array_shift( debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 ) );
+function wp_cache_flush( $delay = 0 ) {
+	if ( version_compare( PHP_VERSION, '5.4.0', '>=' ) ) {
+		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 )[0];
+	} else {
+		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
+		$caller = $caller[0];
+	}
 	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;

--- a/object-cache.php
+++ b/object-cache.php
@@ -1513,7 +1513,11 @@ class WP_Object_Cache {
 			return $this->cache[ $key ];
 		}
 
-		$keys = array_keys( $this->get( 'alloptionskeys', 'options' ) );
+		$alloptionkeys = $this->get( 'alloptionskeys', 'options' );
+		if ( ! is_array( $alloptionkeys ) ) {
+			$alloptionkeys = array();
+		}
+		$keys = array_keys( $alloptionkeys );
 		if ( empty( $keys ) ) {
 			return array();
 		}

--- a/object-cache.php
+++ b/object-cache.php
@@ -280,7 +280,8 @@ function wp_cache_fetch_all() {
  */
 function wp_cache_flush( $delay = 0 ) {
 	if ( version_compare( PHP_VERSION, '5.4.0', '>=' ) ) {
-		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 )[0];
+		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 );
+		$caller = $caller[0];
 	} else {
 		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
 		$caller = $caller[0];

--- a/object-cache.php
+++ b/object-cache.php
@@ -286,12 +286,11 @@ function wp_cache_flush( $delay = 0 ) {
 		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
 		$caller = $caller[0];
 	}
-
-	if ( 'cli' !== php_sapi_name() ) {
+	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;
 	}
-
+	trigger_error( sprintf( 'wp_cache_flush() used, this is broadly not recommended. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 	global $wp_object_cache;
 	return $wp_object_cache->flush( $delay );
 }

--- a/object-cache.php
+++ b/object-cache.php
@@ -278,9 +278,9 @@ function wp_cache_fetch_all() {
  * @param int       $delay  Number of seconds to wait before invalidating the items.
  * @return bool             Returns TRUE on success or FALSE on failure.
  */
-function wp_cache_flush( $delay = 0 ) {
+function wp_cache_flush( $delay = 0 ) {	
+	$caller = array_shift( debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 ) );
 	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
-		$caller = array_shift( debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 ) );
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;
 	}

--- a/object-cache.php
+++ b/object-cache.php
@@ -284,6 +284,7 @@ function wp_cache_flush( $delay = 0 ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;
 	}
+	trigger_error( sprintf( 'wp_cache_flush() used, this is broadly not recommended. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 	global $wp_object_cache;
 	return $wp_object_cache->flush( $delay );
 }

--- a/object-cache.php
+++ b/object-cache.php
@@ -1514,12 +1514,12 @@ class WP_Object_Cache {
 			return $this->cache[ $key ];
 		}
 
-		$keys = $this->get( 'alloptionskeys', 'options' );
+		$keys = array_keys( $this->get( 'alloptionskeys', 'options' ) );
 		if ( empty( $keys ) ) {
 			return array();
 		}
 
-		$data = $this->getMulti( array_keys( $keys ), 'options' );
+		$data = $this->getMulti( $keys, 'options' );
 
 		if ( empty( $data ) ) {
 			return array();
@@ -1527,7 +1527,7 @@ class WP_Object_Cache {
 
 		// getMulti returns a map of `[ cache_key => value ]` but we need to
 		// return a map of `[ option_name => value ]`
-		$data = array_combine( array_keys( $keys ), array_values( $data ) );
+		$data = array_combine( $keys, $data );
 
 		$this->cache[ $key ] = $data;
 		return $data;

--- a/object-cache.php
+++ b/object-cache.php
@@ -1179,6 +1179,10 @@ class WP_Object_Cache {
 	 * @return  bool                    Returns TRUE on success or FALSE on failure.
 	 */
 	public function delete( $key, $group = 'default', $time = 0, $server_key = '', $byKey = false ) {
+		if ( $key === 'alloptions' && $group === 'options' ) {
+			return $this->deleteAllOptions();
+		}
+
 		$derived_key = $this->buildKey( $key, $group );
 
 		// Remove from no_mc_groups array
@@ -1187,10 +1191,6 @@ class WP_Object_Cache {
 				unset( $this->cache[$derived_key] );
 
 			return true;
-		}
-
-		if ( $key === 'alloptions' && $group === 'options' ) {
-			return $this->deleteAllOptions();
 		}
 
 		if ( $byKey )
@@ -1289,14 +1289,15 @@ class WP_Object_Cache {
 	 * @return  bool|mixed                  Cached object value.
 	 */
 	public function get( $key, $group = 'default', $force = false, &$found = null, $server_key = '', $byKey = false, $cache_cb = NULL, &$cas_token = NULL ) {
+		if ( $key === 'alloptions' && $group === 'options' ) {
+			return $this->getAllOptions();
+		}
+
 		$derived_key = $this->buildKey( $key, $group );
 
 		// Assume object is not found
 		$found = false;
 
-		if ( $key === 'alloptions' && $group === 'options' ) {
-			return $this->getAllOptions();
-		}
 		// If either $cache_db, or $cas_token is set, must hit Memcached and bypass runtime cache
 		if ( func_num_args() > 6 && ! in_array( $group, $this->no_mc_groups ) ) {
 			if ( $byKey )

--- a/object-cache.php
+++ b/object-cache.php
@@ -286,11 +286,12 @@ function wp_cache_flush( $delay = 0 ) {
 		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
 		$caller = $caller[0];
 	}
-	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+
+	if ( 'cli' !== php_sapi_name() ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;
 	}
-	trigger_error( sprintf( 'wp_cache_flush() used, this is broadly not recommended. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
+
 	global $wp_object_cache;
 	return $wp_object_cache->flush( $delay );
 }

--- a/object-cache.php
+++ b/object-cache.php
@@ -878,6 +878,10 @@ class WP_Object_Cache {
 			return false;
 		}
 
+		if ( $key === 'alloptions' && $group === 'options' ) {
+			return $this->setAllOptions( $value );
+		}
+
 		$derived_key = $this->buildKey( $key, $group );
 		$expiration  = $this->sanitize_expiration( $expiration );
 
@@ -1185,6 +1189,10 @@ class WP_Object_Cache {
 			return true;
 		}
 
+		if ( $key === 'alloptions' && $group === 'options' ) {
+			return $this->deleteAllOptions();
+		}
+
 		if ( $byKey )
 			$result = $this->m->deleteByKey( $server_key, $derived_key, $time );
 		else
@@ -1286,6 +1294,9 @@ class WP_Object_Cache {
 		// Assume object is not found
 		$found = false;
 
+		if ( $key === 'alloptions' && $group === 'options' ) {
+			return $this->getAllOptions();
+		}
 		// If either $cache_db, or $cas_token is set, must hit Memcached and bypass runtime cache
 		if ( func_num_args() > 6 && ! in_array( $group, $this->no_mc_groups ) ) {
 			if ( $byKey )
@@ -1475,6 +1486,105 @@ class WP_Object_Cache {
 			return $this->getMulti( $keys, $groups, $server_key, $cas_tokens, $flags );
 		else
 			return $this->getMulti( $keys, $groups, $server_key );
+	}
+
+	/**
+	 * Get the "alloptions" special value.
+	 *
+	 * WordPress stores all options under a single memcached key, which can lead to
+	 * race conditions with other updates in other threads. Therefore, we override
+	 * WordPress behaviour and store each option it it's own memcached object, and use
+	 * a secondary object "alloptionskeys" to store all the different keys, this allows
+	 * us to fetch all of the options keys at once using getMulti().
+	 *
+	 * @return array
+	 */
+	public function getAllOptions() {
+		// Check our internal cache, to avoid the more expensive get-multi
+		$key = $this->buildKey( 'alloptions', 'options' );
+		if ( isset( $this->cache[ $key ] ) ) {
+			return $this->cache[ $key ];
+		}
+
+		$keys = $this->get( 'alloptionskeys', 'options' );
+		if ( empty( $keys ) ) {
+			return array();
+		}
+
+		$data = $this->getMulti( array_keys( $keys ), 'options' );
+
+		if ( empty( $data ) ) {
+			return array();
+		}
+
+		$this->cache[ $key ] = $data;
+		return $data;
+	}
+
+	/**
+	 * Update the "alloptions" special key.
+	 *
+	 * This will cause a set on each option value as each option gets it's own
+	 * memcached object, these are then all tied together in the "alloptionskeys"
+	 * object.
+	 *
+	 * @param bool
+	 */
+	public function setAllOptions( $data ) {
+		$internal_cache_key = $this->buildKey( 'alloptions', 'options' );
+		$existing = $internal_cache = $this->getAllOptions();
+
+		$keys = $this->get( 'alloptionskeys', 'options' );
+		if ( empty( $keys ) ) {
+			$keys = array();
+		}
+		// While you could use array_diff here, it ends up being a bit more
+		// complicated than just checking
+		foreach ( $data as $key => $value ) {
+			if ( isset( $existing[ $key ] ) && $existing[ $key ] === $value ) {
+				continue;
+			}
+			if ( ! isset( $keys[ $key ] ) ) {
+				$keys[ $key ] = true;
+			}
+			if ( ! $this->set( $key, $value, 'options' ) ) {
+				return false;
+			}
+
+			$internal_cache[ $key ] = $value;
+		}
+		// Remove deleted elements
+		foreach ( $existing as $key => $value ) {
+			if ( isset( $data[ $key ] ) ) {
+				continue;
+			}
+			if ( isset( $keys[ $key ] ) ) {
+				unset( $keys[ $key ] );
+			}
+			if ( ! $this->delete( $key, 'options' ) ) {
+				return false;
+			}
+
+			unset( $internal_cache[ $key ] );
+		}
+		if ( ! $this->set( 'alloptionskeys', $keys, 'options' ) ) {
+			return false;
+		}
+
+		$this->cache[ $internal_cache_key ] = $internal_cache;
+
+		return true;
+	}
+
+	/**
+	 * Delete the "alloptions" special key.
+	 *
+	 * @return bool
+	 */
+	public function deleteAllOptions() {
+		$key = $this->buildKey( 'alloptions', 'options' );
+		$this->cache[ $key ] = array();
+		return $this->delete( 'alloptionskeys', 'options' );
 	}
 
 	/**
@@ -1775,6 +1885,10 @@ class WP_Object_Cache {
 		if ( in_array( $group, $this->no_mc_groups ) ) {
 			$this->add_to_internal_cache( $derived_key, $value );
 			return true;
+		}
+
+		if ( $key === 'alloptions' && $group === 'options' ) {
+			return $this->setAllOptions( $value );
 		}
 
 		// Save to Memcached

--- a/object-cache.php
+++ b/object-cache.php
@@ -279,8 +279,7 @@ function wp_cache_fetch_all() {
  * @return bool             Returns TRUE on success or FALSE on failure.
  */
 function wp_cache_flush( $delay = 0 ) {
-	$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 );
-	$caller = $caller[0];
+	$caller = array_shift( debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 ) );
 	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;

--- a/object-cache.php
+++ b/object-cache.php
@@ -279,13 +279,8 @@ function wp_cache_fetch_all() {
  * @return bool             Returns TRUE on success or FALSE on failure.
  */
 function wp_cache_flush( $delay = 0 ) {
-	if ( version_compare( PHP_VERSION, '5.4.0', '>=' ) ) {
-		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 );
-		$caller = $caller[0];
-	} else {
-		$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
-		$caller = $caller[0];
-	}
+	$caller = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 );
+	$caller = $caller[0];
 	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
 		return false;

--- a/object-cache.php
+++ b/object-cache.php
@@ -279,6 +279,11 @@ function wp_cache_fetch_all() {
  * @return bool             Returns TRUE on success or FALSE on failure.
  */
 function wp_cache_flush( $delay = 0 ) {
+	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+		$caller = array_shift( debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 ) );
+		trigger_error( sprintf( 'wp_cache_flush() is only allowed via WP CLI. Called in %s line %d', $caller['file'], $caller['line'] ), E_USER_WARNING );
+		return false;
+	}
 	global $wp_object_cache;
 	return $wp_object_cache->flush( $delay );
 }

--- a/object-cache.php
+++ b/object-cache.php
@@ -1524,6 +1524,10 @@ class WP_Object_Cache {
 			return array();
 		}
 
+		// getMulti returns a map of `[ cache_key => value ]` but we need to
+		// return a map of `[ option_name => value ]`
+		$data = array_combine( array_keys( $keys ), array_values( $data ) );
+
 		$this->cache[ $key ] = $data;
 		return $data;
 	}

--- a/tests/tests/alloptions.php
+++ b/tests/tests/alloptions.php
@@ -1,0 +1,25 @@
+<?php
+
+class MemcachedUnitTestsAllOptions extends MemcachedUnitTests {
+	public function test_getting_all_options_keys() {
+		$this->object_cache->set( 'alloptions', array( 'siteurl' => 'http://examples.com/' ), 'options' );
+		$keys = $this->object_cache->get( 'alloptionskeys', 'options' );
+
+		$this->assertEquals( array( 'siteurl' => true ), $keys );
+	}
+
+	public function test_getting_all_options() {
+		$this->object_cache->set( 'alloptions', array( 'siteurl' => 'http://examples.com/' ), 'options' );
+
+		$options = $this->object_cache->get( 'alloptions', 'options' );
+		$this->assertEquals( array( 'http://examples.com/' ), array_values( $options ) );
+	}
+
+	public function test_add_option_updates_alloptions_keys() {
+		add_option( 'jordan', 'parise' );
+		$this->object_cache->set( 'alloptions', array( 'siteurl' => 'http://examples.com/' ), 'options' );
+		$keys = $this->object_cache->get( 'alloptionskeys', 'options' );
+
+		$this->assertTrue( array_key_exists( 'jordan', $keys ) );
+	}
+}

--- a/tests/tests/alloptions.php
+++ b/tests/tests/alloptions.php
@@ -8,11 +8,6 @@ class MemcachedUnitTestsAllOptions extends MemcachedUnitTests {
 		$this->assertEquals( array( 'siteurl' => true ), $keys );
 	}
 
-	public function test_wp_load_alloptions_keys() {
-		$options = wp_load_alloptions();
-		$this->assertTrue( isset( $options['siteurl'] ) );
-	}
-
 	public function test_getting_all_options() {
 		$this->object_cache->set( 'alloptions', array( 'siteurl' => 'http://examples.com/' ), 'options' );
 
@@ -22,7 +17,9 @@ class MemcachedUnitTestsAllOptions extends MemcachedUnitTests {
 
 	public function test_add_option_updates_alloptions_keys() {
 		add_option( 'jordan', 'parise' );
+		$this->object_cache->set( 'alloptions', array( 'siteurl' => 'http://examples.com/' ), 'options' );
 		$keys = $this->object_cache->get( 'alloptionskeys', 'options' );
+
 		$this->assertTrue( array_key_exists( 'jordan', $keys ) );
 	}
 }

--- a/tests/tests/alloptions.php
+++ b/tests/tests/alloptions.php
@@ -8,6 +8,11 @@ class MemcachedUnitTestsAllOptions extends MemcachedUnitTests {
 		$this->assertEquals( array( 'siteurl' => true ), $keys );
 	}
 
+	public function test_wp_load_alloptions_keys() {
+		$options = wp_load_alloptions();
+		$this->assertTrue( isset( $options['siteurl'] ) );
+	}
+
 	public function test_getting_all_options() {
 		$this->object_cache->set( 'alloptions', array( 'siteurl' => 'http://examples.com/' ), 'options' );
 
@@ -17,9 +22,7 @@ class MemcachedUnitTestsAllOptions extends MemcachedUnitTests {
 
 	public function test_add_option_updates_alloptions_keys() {
 		add_option( 'jordan', 'parise' );
-		$this->object_cache->set( 'alloptions', array( 'siteurl' => 'http://examples.com/' ), 'options' );
 		$keys = $this->object_cache->get( 'alloptionskeys', 'options' );
-
 		$this->assertTrue( array_key_exists( 'jordan', $keys ) );
 	}
 }


### PR DESCRIPTION
@joehoyle Whenever I disconnect Memcached I get thousand of warnings:

`PHP Warning:  array_keys() expects parameter 1 to be array, boolean given in /srv/www/wordpress-yell/Yell/content/hm-platform/dropins/wordpress-pecl-memcached-object-cache/object-cache.php on line 1517`

That's annoying when I need to switch it off to test Yell performance.

