### PR TITLE
Performance improvements

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -1990,7 +1990,7 @@ class WP_Object_Cache {
 	 */
 	public function sanitize_expiration( $expiration ) {
 		if ( $expiration > $this->thirty_days && $expiration <= $this->now ) {
-			$expiration = $expiration + $this->now;
+			$expiration += $this->now;
 		}
 
 		return $expiration;

--- a/object-cache.php
+++ b/object-cache.php
@@ -809,6 +809,20 @@ class WP_Object_Cache {
 	public $blog_prefix = '';
 
 	/**
+	 * Thirty days in seconds
+	 *
+	 * @var int
+	 */
+	private $thirty_days = 2592000;
+
+	/**
+	 * Current timestamp holder.
+	 *
+	 * @var int timestamp
+	 */
+	private $now;
+
+	/**
 	 * Instantiate the Memcached class.
 	 *
 	 * Instantiates the Memcached class and returns adds the servers specified
@@ -847,7 +861,6 @@ class WP_Object_Cache {
 		}
 
 		// Setup cacheable values for handling expiration times
-		$this->thirty_days = 60 * 60 * 24 * 30;
 		$this->now         = time();
 	}
 

--- a/object-cache.php
+++ b/object-cache.php
@@ -1941,18 +1941,21 @@ class WP_Object_Cache {
 		if ( ! is_array( $keys ) )
 			$keys = (array) $keys;
 
+		$groups_count = count( $groups );
+		$keys_count = count( $keys );
+
 		// If we have equal numbers of keys and groups, merge $keys[n] and $group[n]
-		if ( count( $keys ) == count( $groups ) ) {
-			for ( $i = 0; $i < count( $keys ); $i++ ) {
+		if ( $keys_count === $groups_count ) {
+			for ( $i = 0; $i < $keys_count; $i++ ) {
 				$derived_keys[] = $this->buildKey( $keys[$i], $groups[$i] );
 			}
 
 		// If more keys are received than groups, merge $keys[n] and $group[n] until no more group are left; remaining groups are 'default'
-		} elseif ( count( $keys ) > count( $groups ) ) {
-			for ( $i = 0; $i < count( $keys ); $i++ ) {
+		} elseif ( $keys_count > $groups_count ) {
+			for ( $i = 0; $i < $keys_count; $i++ ) {
 				if ( isset( $groups[$i] ) )
 					$derived_keys[] = $this->buildKey( $keys[$i], $groups[$i] );
-				elseif ( count( $groups ) == 1 )
+				elseif ( $groups_count === 1 )
 					$derived_keys[] = $this->buildKey( $keys[$i], $groups[0] );
 				else
 					$derived_keys[] = $this->buildKey( $keys[$i], 'default' );

--- a/object-cache.php
+++ b/object-cache.php
@@ -835,7 +835,7 @@ class WP_Object_Cache {
 	public function __construct( $persistent_id = NULL ) {
 		global $memcached_servers, $blog_id, $table_prefix;
 
-		if ( is_null( $persistent_id ) || ! is_string( $persistent_id ) )
+		if ( null === $persistent_id || ! is_string( $persistent_id ) )
 			$this->m = new Memcached();
 		else
 			$this->m = new Memcached( $persistent_id );


### PR DESCRIPTION
Some simple performance improvements.

Only count the contents of the keys and groups once.
Use direct `null` checking instead of a function.
Define the class properties and set the value as number instead of calculation.