### PR TITLE
Fix README formatting.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,94 +11,99 @@ This project is a WordPress object cache backend that implements all available m
 	For Ubuntu and Debian:
 
 	```bash
-apt-get install memcached
+	apt-get install memcached
 	```
+
 	For CentOS:
 
 	```bash
-yum install memcached
+	yum install memcached
 	```
 
 	Note that you will likely want to review the Memcached configuration [directives](http://serverfault.com/questions/347621/memcache-basic-configuration). To get the best results from Memcached, you will need to configure it for your system and use case.
 
-1. Start the Memcached daemon:
+2. Start the Memcached daemon:
 
 	```bash
-service memcached restart
+	service memcached restart
 	```
 
-1. Verify that Memcached is installed and running. 
+3. Verify that Memcached is installed and running.
 
-	1. From your server, `telnet` into the Memcached server
+	1. From your server, `telnet` into the Memcached server:
 
 		```bash
-telnet localhost 11211
+		telnet localhost 11211
 		```
 		
 		You should see output like:
 
 		```bash
-Trying 127.0.0.1...
-Connected to localhost.
-Escape character is '^]'.
+		Trying 127.0.0.1...
+		Connected to localhost.
+		Escape character is '^]'.
 		```
 
-	1. Type `version` into the Telnet prompt. If Memcached is installed and running, you should see something like:
+	2. Type "version" into the Telnet prompt. If Memcached is installed and running, you should see something like:
 
 		```bash
-VERSION 1.4.14 (Ubuntu)
+		VERSION 1.4.14 (Ubuntu)
 		```
 
-	1. Exit Telnet by typing `ctrl` + `]`, hitting `enter`, then typing `quit` and pressing `enter`.
+	3. Exit Telnet by typing <kbd>ctrl</kbd> + <kbd>]</kbd>, hitting <kbd>enter</kbd>, then typing "quit" and pressing <kbd>enter</kbd>.
 
-1. Install the Memcached PECL extension on your server. Note that there are two different PHP interfaces for Memcached; one is named PECL Memcache and the other, PECL Memcached. The "d" at the end of Memcached is extremely important in this case. You should be able to install PECL Memcached from your package manager for your Linux distro. 
+4. Install the Memcached PECL extension on your server.
+
+	> Note that there are two different PHP interfaces for Memcached; one is named PECL Memcache and the other, PECL Memcached. The "d" at the end of Memcached is extremely important in this case. You should be able to install PECL Memcached from your package manager for your Linux distro.
 
 	For Ubuntu and Debian:
 
 	```bash
-apt-get install php5-memcached
+	apt-get install php5-memcached
 	```
 
 	For CentOS:
 
 	```bash
-yum install php-pecl-memcached
+	yum install php-pecl-memcached
 	```
 
 	Note that if you have a more custom installation of PHP, you might need to take some extra steps to link the PECL Memcached extension to PHP. If you are setting this up using your package manager's version of PHP and PECL Memcached, this should not be necessary. For example, many `yum.conf` files will exclude packages that begin with `php`. You may be able to modify the configuration file as necessary to install this package.
 
-1. Verify that the Memcached daemon is running and accessible via the PECL Memcached extension in PHP. The easiest way to test this is to run a simple PHP script that connects to Memcached and tries to set and retrieve a value.
+5. Verify that the Memcached daemon is running and accessible via the PECL Memcached extension in PHP. The easiest way to test this is to run a simple PHP script that connects to Memcached and tries to set and retrieve a value.
 
 	1. Enter PHP's interactive shell:
 
 		```bash
-php -a
+		php -a
 		```
 
-	1. Type the following in the interactive shell:
+	2. Type the following in the interactive shell:
 
 		```bash
-php > $m = new Memcached();
-php > $m->addServer( '127.0.0.1', 11211 );
-php > $m->set( 'foo', 100 );
-php > echo $m->get( 'foo' ) . "\n";
+		php > $m = new Memcached();
+		php > $m->addServer( '127.0.0.1', 11211 );
+		php > $m->set( 'foo', 100 );
+		php > echo $m->get( 'foo' ) . "\n";
 		```
 
-	1. If that last command returns `100`, everything is working! If you get blank output, something is amiss.
+	3. If that last command returns `100`, everything is working! If you get blank output, something is amiss.
 
 		Note that if your PHP configuration does not support the interactive shell, you can use the code above to create a script to execute in the browser. The interactive shell is easier for the verification step as it does not require a functioning web server.
 
-1. Now that the server dependencies are resolved, the rest of the configuration is in the WordPress application. Take the **object-cache.php** file and place it in your **wp-content** folder. For instance, if the root of your WordPress installation is at **/srv/www/wordpress**, the location of **object-cache.php** would be **/srv/www/wordpress/wp-content/object-cache.php**. Please note that **object-cache.php** is a [WordPress drop-in](http://hakre.wordpress.com/2010/05/01/must-use-and-drop-ins-plugins/). It is not a regular plugin or an MU plugin. Drop-ins are located directly in the **wp-content** folder.
+6. Now that the server dependencies are resolved, the rest of the configuration is in the WordPress application. Take the `object-cache.php` file and place it in your `wp-content/` folder. For instance, if the root of your WordPress installation is at `/srv/www/wordpress`, the location of `object-cache.php` would be `/srv/www/wordpress/wp-content/object-cache.php`.
 
-1. Add the following to your **wp-config.php** file:
+	> Please note that `object-cache.php` is a [WordPress drop-in](http://hakre.wordpress.com/2010/05/01/must-use-and-drop-ins-plugins/). It is not a regular plugin or an MU plugin. Drop-ins are located directly in the `wp-content` folder.
+
+7. Add the following to your `wp-config.php` file:
 
 	```php
 	global $memcached_servers;
 	$memcached_servers = array(
 	    array(
 	        '127.0.0.1', // Memcached server IP address
-	        11211        // Memcached server port
-	    )
+	        11211,       // Memcached server port
+	    ),
 	);
 	```
 
@@ -113,12 +118,12 @@ php > echo $m->get( 'foo' ) . "\n";
 	    ),
 	    array(
 	        '1.2.3.5',
-	        11211
-	    )
+	        11211,
+	    ),
 	);
 	```
 
-1. To test the WordPress object cache setup, add the following code as an MU plugin:
+8. To test the WordPress object cache setup, add the following code as an MU plugin:
 
 	```php
 	<?php


### PR DESCRIPTION
The current README file formatting doesn't properly indent the contents of code fences, resulting in all sorts of odd rendering:

![Rendered README file for tollmanz/wordpress-pecl-memcached-object-cache at commit e412467](https://user-images.githubusercontent.com/233836/38326822-ccf46cfa-3814-11e8-80e6-2ba8326f2d7f.png)

